### PR TITLE
Add some event-related helpers, as well as event.memberships

### DIFF
--- a/popolo_data/base.py
+++ b/popolo_data/base.py
@@ -558,6 +558,7 @@ class Event(CurrentMixin, PopoloObject):
 class PopoloCollection(object):
 
     def __init__(self, data_list, object_class, all_popolo):
+        self.all_popolo = all_popolo
         self.object_class = object_class
         self.object_list = \
             [self.object_class(data, all_popolo) for data in data_list]
@@ -635,3 +636,15 @@ class EventCollection(PopoloCollection):
     def __init__(self, events_data, all_popolo):
         super(EventCollection, self).__init__(
             events_data, Event, all_popolo)
+
+    @property
+    def elections(self):
+        elections_list = self.filter(classification='general election')
+        elections_data = [election.data for election in elections_list]
+        return EventCollection(elections_data, self.all_popolo)
+
+    @property
+    def legislative_periods(self):
+        lps_list = self.filter(classification='legislative period')
+        legislative_periods_data = [lp.data for lp in lps_list]
+        return EventCollection(legislative_periods_data, self.all_popolo)

--- a/popolo_data/base.py
+++ b/popolo_data/base.py
@@ -556,10 +556,11 @@ class Event(CurrentMixin, PopoloObject):
 
     @property
     def memberships(self):
-        return [
-            m for m in self.all_popolo.memberships
+        memberships_list = [
+            m.data for m in self.all_popolo.memberships
             if m.legislative_period_id == self.id
         ]
+        return MembershipCollection(memberships_list, self.all_popolo)
 
 
 class PopoloCollection(object):

--- a/popolo_data/base.py
+++ b/popolo_data/base.py
@@ -554,6 +554,13 @@ class Event(CurrentMixin, PopoloObject):
     def identifiers(self):
         return self.get_related_object_list('identifiers')
 
+    @property
+    def memberships(self):
+        return [
+            m for m in self.all_popolo.memberships
+            if m.legislative_period_id == self.id
+        ]
+
 
 class PopoloCollection(object):
 

--- a/popolo_data/importer.py
+++ b/popolo_data/importer.py
@@ -47,3 +47,24 @@ class Popolo(object):
     @property
     def events(self):
         return EventCollection(self.json_data.get('events', []), self)
+
+    @property
+    def elections(self):
+        return self.events.elections
+
+    @property
+    def legislative_periods(self):
+        return self.events.legislative_periods
+
+    @property
+    def terms(self):
+        return self.legislative_periods
+
+    @property
+    def latest_legislative_period(self):
+        lps = self.legislative_periods
+        return max(lps, key=lambda lp: lp.start_date.midpoint_date)
+
+    @property
+    def latest_term(self):
+        return self.latest_legislative_period

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -103,6 +103,32 @@ EXAMPLE_MULTIPLE_EVENTS = b'''
             "organization_id": "1ba661a9-22ad-4d0f-8a60-fe8e28f2488c",
             "start_date": "2015-03-30"
         }
+    ],
+    "memberships": [
+        {
+            "area_id": "area/tartu_linn",
+            "legislative_period_id": "term/13",
+            "on_behalf_of_id": "IRL",
+            "organization_id": "1ba661a9-22ad-4d0f-8a60-fe8e28f2488c",
+            "person_id": "014f1aac-a694-4538-8b4f-a533233acb60",
+            "role": "member",
+            "start_date": "2015-04-09"
+        },
+        {
+            "legislative_period_id": "term/12",
+            "on_behalf_of_id": "IRL",
+            "organization_id": "1ba661a9-22ad-4d0f-8a60-fe8e28f2488c",
+            "person_id": "0259486a-0410-49f3-aef9-8b79c15741a7",
+            "role": "member"
+        },
+        {
+            "area_id": "area/harju-_ja_raplamaa",
+            "legislative_period_id": "term/13",
+            "on_behalf_of_id": "RE",
+            "organization_id": "1ba661a9-22ad-4d0f-8a60-fe8e28f2488c",
+            "person_id": "06d37ec8-45bc-44fe-a138-3427ef12c8dc",
+            "role": "member"
+        }
     ]
 }
 '''
@@ -246,3 +272,10 @@ class TestEvents(TestCase):
             legislative_period = popolo.latest_legislative_period
             assert legislative_period.id == 'term/13'
             assert legislative_period == popolo.latest_term
+
+    def test_event_memberships(self):
+        with example_file(EXAMPLE_MULTIPLE_EVENTS) as fname:
+            popolo = Popolo.from_filename(fname)
+            term = popolo.latest_term
+            memberships = term.memberships
+            assert len(memberships) == 2


### PR DESCRIPTION
These are [present in everypolitician-popolo](https://github.com/everypolitician/everypolitician-popolo/blob/40dc460d8340df9ae78469b755ce73b4fd074ce3/lib/everypolitician/popolo.rb#L51-L63), so I thought they might be worth adding here too:

 * `popolo.elections`
 * `popolo.legislative_periods` (`popolo.terms`)
 * `popolo.latest_legislative_period` (`popolo.latest_term`)
 * `events.elections`
 * `events.legislative_periods`
 * `event.memberships`

This allows you to easily get the latest term (`popolo.latest_term`), and get the memberships for this term (`popolo.latest_term.memberships`). All the stuff from the example in #9.

`event.memberships` fixes #8… Although slightly weird that you can get memberships for an election. I wonder if moving this to a separate `LegislativePeriodCollection` might be clearer (as in the ruby version).